### PR TITLE
Adding a horizontal divider below subtitle in Friends List (#229)

### DIFF
--- a/src/friends/friends-container.js
+++ b/src/friends/friends-container.js
@@ -28,6 +28,11 @@ class FriendsContainer extends HTMLElement {
                             Friends within 30 miles of you
                         </li>
 
+                        <li>
+                          <hr class="border-t border-base-300 dark:border-slate-700 mx-4 my-2" />
+                        </li>
+
+
                         <template x-for="friend in friends" :key="friend.friend_id">
                             <li class="list-row friend-row">
                                 <div>


### PR DESCRIPTION
# 🛠️ Description

This PR adds a horizontal divider below the "Friends within 30 miles of you" subtitle in the Friends List component.

This improves visual structure and separates the section header from the list of friends for better readability and a cleaner UI.

---

# ✅ Changes Made

- Added a `<hr>` element with Tailwind styling inside `friends-container.js`, just below the subtitle `<li>` in the friends list.

```html
<li>
  <hr class="border-t border-base-300 dark:border-slate-700 mx-4 my-2" />
</li>
