### PR TITLE
refresh event feed after removing friend, fixes-277

### DIFF
--- a/src/events/events-container.js
+++ b/src/events/events-container.js
@@ -96,6 +96,11 @@ function eventsData() {
       document.addEventListener('friend-added', async () => {
         await this.loadEvents();
       });
+
+      // Listen for the 'friend-removed' event and refresh events
+      window.addEventListener('friend-removed', async () => {
+        await this.loadEvents();
+      });
     },
 
     showToastNotification(message, type = 'success') {

--- a/src/events/events-container.js
+++ b/src/events/events-container.js
@@ -93,12 +93,7 @@ function eventsData() {
       });
 
       // Listen for the 'friend-added' event and refresh events
-      document.addEventListener('friend-added', async () => {
-        await this.loadEvents();
-      });
-
-      // Listen for the 'friend-removed' event and refresh events
-      window.addEventListener('friend-removed', async () => {
+      window.addEventListener('friend-list-changed', async () => {
         await this.loadEvents();
       });
     },

--- a/src/friends/friends-container.js
+++ b/src/friends/friends-container.js
@@ -100,8 +100,7 @@ function friendsData() {
       try {
         await apiRemoveFriendship(friendId);
         await this.loadFriends();
-        const event = new CustomEvent('friend-removed', { bubbles: true, composed: true });
-        window.dispatchEvent(event); // Changed from this.$el.dispatchEvent
+        this.FriendListChangedEvent();
       } catch (err) {
         console.error('Error in AlpineJS removeFriendship:', err);
       }
@@ -120,15 +119,18 @@ function friendsData() {
         await insertFriendship(username);
         input.value = '';
         await this.loadFriends();
-        // Dispatch a custom event when a friend is added
-        const event = new CustomEvent('friend-added', { bubbles: true });
-        this.$el.dispatchEvent(event);
+        this.FriendListChangedEvent();
       } catch (err) {
         console.error('Failed to add friend:', err);
       } finally {
         this.isAddingFriend = false;
       }
     },
+    FriendListChangedEvent() {
+      const event = new CustomEvent('friend-list-changed', { bubbles: true, composed: true  });
+      window.dispatchEvent(event);
+    }
+    
   };
 }
 

--- a/src/friends/friends-container.js
+++ b/src/friends/friends-container.js
@@ -100,6 +100,8 @@ function friendsData() {
       try {
         await apiRemoveFriendship(friendId);
         await this.loadFriends();
+        const event = new CustomEvent('friend-removed', { bubbles: true, composed: true });
+        window.dispatchEvent(event); // Changed from this.$el.dispatchEvent
       } catch (err) {
         console.error('Error in AlpineJS removeFriendship:', err);
       }


### PR DESCRIPTION
New Event has been created that refreshes the feed once a friend is removed