### PR TITLE
Extract Pages into a list of constants for readability

### DIFF
--- a/events.html
+++ b/events.html
@@ -11,6 +11,9 @@
   <title>Events - Pencil It In</title>
   <script type="module">
       import {protectPage} from '@/auth/services/redirect.js';
+      import {PAGES} from './src/constants/pages.ts';
+
+      window.PAGES = PAGES;  // add PAGES to global scope for use in HTML later
 
       protectPage();
   </script>
@@ -23,15 +26,15 @@
 <div class="safe-area-bottom"></div>
 <!-- end safe area for mobile devices -->
 
-<div id="main-container mx-auto" x-data="{ page: 'events' }">
+<div id="main-container mx-auto" x-data="{ page: PAGES.EVENTS }">
   <site-header></site-header>
-  <div class="lg:m-16 2xl:mx-32 max-w-[90rem] flex" id="body-container">
+  <div id="body-container" class="lg:m-16 2xl:mx-32 max-w-[90rem] flex">
     <bottom-menu class="block lg:hidden"></bottom-menu>
     <sidebar-menu class="hidden lg:block"></sidebar-menu>
     <!--    todo fix title so that it correctly passes in 'page' from x-data -->
     <main-content-container
-        class="flex flex-1 mb-24 sm:mb-0"
         id="main-content-container"
+        class="flex flex-1 mb-24 sm:mb-0"
         x-data="{ capitalize(str) { return str.charAt(0).toUpperCase() + str.slice(1) } }"
     >
     </main-content-container>

--- a/src/components/sidebar-menu.js
+++ b/src/components/sidebar-menu.js
@@ -1,13 +1,15 @@
+import { PAGES } from '../constants/pages.ts';
+
 class SidebarMenu extends HTMLElement {
   connectedCallback() {
     this.innerHTML = `
       <ul class="menu menu-xl w-80 bg-base-200 lg:menu-vertical rounded-box">
         <li>
           <a 
-          @click="page = 'events'"
+          @click="page = '${PAGES.EVENTS}'"
           id="menu-item-events" 
           class="sidebar-menu-item"
-          :class="page === 'events' ? 'menu-active' : ''"
+          :class="page === '${PAGES.EVENTS}' ? 'menu-active' : ''"
           >
             <iconify-icon icon="mdi:calendar"></iconify-icon>
             Events
@@ -17,11 +19,11 @@ class SidebarMenu extends HTMLElement {
         </li>
         <li>
           <a 
-          @click="page = 'friends'"
+          @click="page = '${PAGES.FRIENDS}'"
           data-testid="friends-menu-item"
           id="menu-item-friends" 
           class="sidebar-menu-item"
-          :class="page === 'friends' ? 'menu-active' : ''"
+          :class="page === '${PAGES.FRIENDS}' ? 'menu-active' : ''"
           >
             <iconify-icon icon="mdi:account-group"></iconify-icon>
             Friends
@@ -30,10 +32,10 @@ class SidebarMenu extends HTMLElement {
         </li>
         <li>
           <a 
-          @click="page = 'profile'"
+          @click="page = '${PAGES.PROFILE}'"
           id="menu-item-profile" 
           class="sidebar-menu-item"
-          :class="page === 'profile' ? 'menu-active' : ''"
+          :class="page === '${PAGES.PROFILE}' ? 'menu-active' : ''"
           >
             <iconify-icon icon="mdi:user"></iconify-icon>
             Profile

--- a/src/constants/pages.ts
+++ b/src/constants/pages.ts
@@ -1,0 +1,10 @@
+// src/constants/pages.ts
+// Centralized page name constants for the app
+
+export const PAGES = {
+  EVENTS: 'events',
+  FRIENDS: 'friends',
+  PROFILE: 'profile',
+  LANDING: 'landing',
+  // Add other pages as needed
+};


### PR DESCRIPTION
## Improves code readability and visibility of website pages.
**Closes #386**

Pages weren't initialized anywhere and were arbitrarily set in `sidebar_menu.js`. Added constants so it's easy for anyone to see what pages we have.

`events.html` initializes the page variable at `x-data="{ page: 'events' }">`

